### PR TITLE
Fix bug group name overlaps links

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -276,6 +276,8 @@ A:hover {
 /* Links list
 ------------------------------ */
 .list-links {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   margin: 0;


### PR DESCRIPTION
Fixed a small bug when `.list-data__group-name` overlaps interactive links contained in `.list-links`. So mouse interaction with these links becomes impossible.